### PR TITLE
Subtract: Remove the intersection of two ranges

### DIFF
--- a/docs/pages/examples/Make_a_subtracted_time_range.rst
+++ b/docs/pages/examples/Make_a_subtracted_time_range.rst
@@ -1,0 +1,16 @@
+Make an subtracted time range
+------------------------------
+:Sample Code:
+    .. code:: python
+
+        from datetimerange import DateTimeRange
+        time_range = DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:00:00+0900")
+        x = DateTimeRange("2015-01-22T09:55:00+0900", "2015-01-22T09:56:00+0900")
+        time_range.subtract(x)
+
+:Output:
+    ::
+
+        [2015-01-22T09:50:00+0900 - 2015-01-22T09:55:00+0900,
+         2015-01-22T09:56:00+0900 - 2015-01-22T10:00:00+0900]
+

--- a/docs/pages/examples/index.rst
+++ b/docs/pages/examples/index.rst
@@ -46,5 +46,6 @@ time-string in the following examples.
 .. include:: Test_whether_a_value_within_the_time_range.rst
 .. include:: Test_whether_a_value_intersect_the_time_range.rst
 .. include:: Make_an_intersected_time_range.rst
+.. include:: Make_a_subtracted_time_range.rst
 .. include:: Make_an_encompassed_time_range.rst
 .. include:: Truncate_time_range.rst

--- a/test/test_dtr.py
+++ b/test/test_dtr.py
@@ -730,6 +730,94 @@ class TestDateTimeRange_is_intersection:
             lhs.is_intersection(rhs)
 
 
+class TestDateTimeRange_subtract:
+    @pytest.mark.parametrize(
+        ["lhs", "rhs", "expected"],
+        [
+            [
+                DateTimeRange(TEST_START_DATETIME, TEST_END_DATETIME),
+                DateTimeRange(TEST_START_DATETIME, TEST_END_DATETIME),
+                [],
+            ],
+            [
+                DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:00:00+0900"),
+                DateTimeRange("2015-01-22T09:30:00+0900", "2015-01-22T10:30:00+0900"),
+                [],
+            ],
+            [
+                DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:30:00+0900"),
+                DateTimeRange("2015-01-22T10:40:00+0900", "2015-01-22T10:50:00+0900"),
+                [DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:30:00+0900")],
+            ],
+            [
+                DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:30:00+0900"),
+                DateTimeRange("2015-01-22T09:55:00+0900", "2015-01-22T09:55:00+0900"),
+                [DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:30:00+0900")],
+            ],
+            [
+                DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:30:00+0900"),
+                DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:00:00+0900"),
+                [DateTimeRange("2015-01-22T10:00:00+0900", "2015-01-22T10:30:00+0900")],
+            ],
+            [
+                DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:30:00+0900"),
+                DateTimeRange("2015-01-22T09:30:00+0900", "2015-01-22T10:00:00+0900"),
+                [DateTimeRange("2015-01-22T10:00:00+0900", "2015-01-22T10:30:00+0900")],
+            ],
+            [
+                DateTimeRange("2015-01-22T09:30:00+0900", "2015-01-22T10:00:00+0900"),
+                DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:00:00+0900"),
+                [DateTimeRange("2015-01-22T09:30:00+0900", "2015-01-22T09:50:00+0900")],
+            ],
+            [
+                DateTimeRange("2015-01-22T09:30:00+0900", "2015-01-22T10:00:00+0900"),
+                DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:10:00+0900"),
+                [DateTimeRange("2015-01-22T09:30:00+0900", "2015-01-22T09:50:00+0900")],
+            ],
+            [
+                DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T10:00:00+0900"),
+                DateTimeRange("2015-01-22T09:55:00+0900", "2015-01-22T09:56:00+0900"),
+                [
+                    DateTimeRange("2015-01-22T09:50:00+0900", "2015-01-22T09:55:00+0900"),
+                    DateTimeRange("2015-01-22T09:56:00+0900", "2015-01-22T10:00:00+0900"),
+                ],
+            ],
+        ],
+    )
+    def test_normal(self, lhs, rhs, expected):
+        assert lhs.subtract(rhs) == expected
+
+    @pytest.mark.parametrize(
+        ["lhs", "rhs", "expected"],
+        [
+            [DateTimeRange(None, None), DateTimeRange(None, None), TypeError],
+            [
+                DateTimeRange(None, TEST_END_DATETIME),
+                DateTimeRange(TEST_START_DATETIME, TEST_END_DATETIME),
+                TypeError,
+            ],
+            [
+                DateTimeRange(TEST_END_DATETIME, TEST_START_DATETIME),
+                DateTimeRange(TEST_START_DATETIME, TEST_END_DATETIME),
+                ValueError,
+            ],
+            [
+                DateTimeRange(TEST_START_DATETIME, TEST_END_DATETIME),
+                DateTimeRange(None, TEST_END_DATETIME),
+                TypeError,
+            ],
+            [
+                DateTimeRange(TEST_START_DATETIME, TEST_END_DATETIME),
+                DateTimeRange(TEST_END_DATETIME, TEST_START_DATETIME),
+                ValueError,
+            ],
+        ],
+    )
+    def test_exception(self, lhs, rhs, expected):
+        with pytest.raises(expected):
+            lhs.subtract(rhs)
+
+
 class TestDateTimeRange_get_start_time_str:
     @pytest.mark.parametrize(
         ["time_format", "expected"],


### PR DESCRIPTION
Subtracting two ranges will result in an array of ranges:
empty set -- the second range is equal or greater than the first
single set -- the second set overlaps the beginning or end of the first or does not intersect at all
two ranges -- the second set is within the first and slices it into two new pieces