### PR TITLE
Make spaces in separator configurable

### DIFF
--- a/datetimerange/__init__.py
+++ b/datetimerange/__init__.py
@@ -836,7 +836,7 @@ class DateTimeRange:
     def from_range_text(
         cls,
         range_text: str,
-        separator: str = "-",
+        separator: str = " - ",
         start_time_format: Optional[str] = None,
         end_time_format: Optional[str] = None,
     ) -> "DateTimeRange":
@@ -853,7 +853,7 @@ class DateTimeRange:
             Created instance.
         """
 
-        dattime_ranges = re.split(r"\s+{}\s+".format(re.escape(separator)), range_text.strip())
+        dattime_ranges = re.split(r"{}".format(re.escape(separator)), range_text.strip())
         if len(dattime_ranges) != 2:
             raise ValueError("range_text should include two datetime that separated by hyphen")
 


### PR DESCRIPTION
The current implementation of `from_range_text()` allows to define the separator, but has hardcoded spaces around them. This is not always the case (see as an example, the [STAC api specs datetime](https://api.stacspec.org/v1.0.0-rc.1/item-search/#tag/Item-Search/operation/getItemSearch) uses ).

Suggesting to remove the hardcoded spaces and make them configurable through the `separator` argument.
